### PR TITLE
Better list of Constants

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yard-markdown (0.4)
+    yard-markdown (0.4.1)
       csv
       yard
 

--- a/example/Aquatic.md
+++ b/example/Aquatic.md
@@ -12,7 +12,7 @@ Swim in the water.
 
 
 # Constants
-| Name | Value |
+| Name | Default Value |
 | ---  | ---   |
 | [DEFAULT_SALMON_SPEED](#constant-DEFAULT_SALMON_SPEED) | 20 |
 | [MAX_DEPTH](#constant-MAX_DEPTH) | 500 |

--- a/example/Aquatic.md
+++ b/example/Aquatic.md
@@ -12,7 +12,7 @@ Swim in the water.
 
 
 # Constants
-| Name | Value | Title |
-| ---  | ---   | ---   |
-| [DEFAULT_SALMON_SPEED](#constant-DEFAULT_SALMON_SPEED) | 20 |:: |
-| [MAX_DEPTH](#constant-MAX_DEPTH) | 500 |:: |
+| Name | Value |
+| ---  | ---   |
+| [DEFAULT_SALMON_SPEED](#constant-DEFAULT_SALMON_SPEED) | 20 |
+| [MAX_DEPTH](#constant-MAX_DEPTH) | 500 |

--- a/example/Aquatic.md
+++ b/example/Aquatic.md
@@ -8,13 +8,11 @@ A mixin for aquatic creatures.
 ## swim() [](#method-i-swim)
 Swim in the water.
 
-**return** [void] 
+**@return** [void] 
 
 
 # Constants
-## DEFAULT_SALMON_SPEED [](#constant-DEFAULT_SALMON_SPEED)
-
-
-## MAX_DEPTH [](#constant-MAX_DEPTH)
-
-
+| Name | Value | Title |
+| ---  | ---   | ---   |
+| [DEFAULT_SALMON_SPEED](#constant-DEFAULT_SALMON_SPEED) | 20 |:: |
+| [MAX_DEPTH](#constant-MAX_DEPTH) | 500 |:: |

--- a/example/Fish.md
+++ b/example/Fish.md
@@ -27,7 +27,7 @@ swim(:north, 30)
 ```
 
 # Constants
-| Name | Value |
+| Name | Default Value |
 | ---  | ---   |
 | [DEFAULT_SALMON_SPEED](#constant-DEFAULT_SALMON_SPEED) | 20 |
 | [MAX_DEPTH](#constant-MAX_DEPTH) | 500 |

--- a/example/Fish.md
+++ b/example/Fish.md
@@ -27,7 +27,7 @@ swim(:north, 30)
 ```
 
 # Constants
-| Name | Value | Title |
-| ---  | ---   | ---   |
-| [DEFAULT_SALMON_SPEED](#constant-DEFAULT_SALMON_SPEED) | 20 |:: |
-| [MAX_DEPTH](#constant-MAX_DEPTH) | 500 |:: |
+| Name | Value |
+| ---  | ---   |
+| [DEFAULT_SALMON_SPEED](#constant-DEFAULT_SALMON_SPEED) | 20 |
+| [MAX_DEPTH](#constant-MAX_DEPTH) | 500 |

--- a/example/Fish.md
+++ b/example/Fish.md
@@ -9,27 +9,25 @@ The base class for all fish.
 ## make_sound() [](#method-i-make_sound)
 Make a sound.
 
-**return** [void] 
-**yield** [sound] The sound produced by the fish
-**yieldparam** [String] The actual sound
+**@return** [void] 
+**@yield** [sound] The sound produced by the fish
+**@yieldparam** [String] The actual sound
 ## swim(direction, speed) [](#method-i-swim)
 Swim in a specific direction.
 
 Swimming is the most critical feature of fish.
 
-**param** [Symbol, String] The direction to swim
-**param** [Integer] The speed at which to swim
-**return** [Boolean] Whether the swim was successful
+**@param** [Symbol, String] The direction to swim
+**@param** [Integer] The speed at which to swim
+**@return** [Boolean] Whether the swim was successful
 
-**example**
+**@example**
 ```ruby
 swim(:north, 30)
 ```
 
 # Constants
-## DEFAULT_SALMON_SPEED [](#constant-DEFAULT_SALMON_SPEED)
-
-
-## MAX_DEPTH [](#constant-MAX_DEPTH)
-
-
+| Name | Value | Title |
+| ---  | ---   | ---   |
+| [DEFAULT_SALMON_SPEED](#constant-DEFAULT_SALMON_SPEED) | 20 |:: |
+| [MAX_DEPTH](#constant-MAX_DEPTH) | 500 |:: |

--- a/example/Salmon.md
+++ b/example/Salmon.md
@@ -50,7 +50,7 @@ Swim in the water.
 **@return** [Boolean] True for wild salmon
 
 # Constants
-| Name | Value |
+| Name | Default Value |
 | ---  | ---   |
 | [DEFAULT_SALMON_SPEED](#constant-DEFAULT_SALMON_SPEED) | 20 |
 | [MAX_DEPTH](#constant-MAX_DEPTH) | 500 |

--- a/example/Salmon.md
+++ b/example/Salmon.md
@@ -50,7 +50,7 @@ Swim in the water.
 **@return** [Boolean] True for wild salmon
 
 # Constants
-| Name | Value | Title |
-| ---  | ---   | ---   |
-| [DEFAULT_SALMON_SPEED](#constant-DEFAULT_SALMON_SPEED) | 20 |:: |
-| [MAX_DEPTH](#constant-MAX_DEPTH) | 500 |:: |
+| Name | Value |
+| ---  | ---   |
+| [DEFAULT_SALMON_SPEED](#constant-DEFAULT_SALMON_SPEED) | 20 |
+| [MAX_DEPTH](#constant-MAX_DEPTH) | 500 |

--- a/example/Salmon.md
+++ b/example/Salmon.md
@@ -19,40 +19,38 @@ A salmon is an Aquatic Fish.
 ## initialize(farmed, wild) [](#method-i-initialize)
 Creates a new salmon.
 
-**param** [Boolean] Whether the salmon is farmed
-**param** [Boolean] Whether the salmon is wild
-**return** [Salmon] a new instance of Salmon
+**@param** [Boolean] Whether the salmon is farmed
+**@param** [Boolean] Whether the salmon is wild
+**@return** [Salmon] a new instance of Salmon
 ## make_sound() [](#method-i-make_sound)
 Salmon overrides generic implementation.
 
-**return** [void] 
-**yield** [sound] The sound produced by the salmon
-**yieldparam** [String] The actual sound
+**@return** [void] 
+**@yield** [sound] The sound produced by the salmon
+**@yieldparam** [String] The actual sound
 ## sustainable?() [](#method-i-sustainable?)
 Checks if this salmon is sustainable.
 
-**return** [Boolean] Whether the salmon is sustainable
+**@return** [Boolean] Whether the salmon is sustainable
 ## swim() [](#method-i-swim)
 Swim in the water.
 
-**return** [void] 
+**@return** [void] 
 
 # Public Class Methods
 ## wild_salmon() [](#method-c-wild_salmon)
-**return** [Array<Salmon>] List of all wild salmon
+**@return** [Array<Salmon>] List of all wild salmon
 
 # Attributes
 ## farmed[RW] [](#attribute-i-farmed)
 
-**return** [Boolean] True for farmed salmon
+**@return** [Boolean] True for farmed salmon
 ## wild[RW] [](#attribute-i-wild)
 
-**return** [Boolean] True for wild salmon
+**@return** [Boolean] True for wild salmon
 
 # Constants
-## DEFAULT_SALMON_SPEED [](#constant-DEFAULT_SALMON_SPEED)
-
-
-## MAX_DEPTH [](#constant-MAX_DEPTH)
-
-
+| Name | Value | Title |
+| ---  | ---   | ---   |
+| [DEFAULT_SALMON_SPEED](#constant-DEFAULT_SALMON_SPEED) | 20 |:: |
+| [MAX_DEPTH](#constant-MAX_DEPTH) | 500 |:: |

--- a/example_yard.rb
+++ b/example_yard.rb
@@ -1,12 +1,8 @@
-# @title YARD Markdown Example
-# @description This example demonstrates various YARD features using markdown formatting.
-#
-# ## Links
-#
-# 1. [YARD Documentation](https://yardoc.org/)
-# 2. [Markdown Syntax](https://daringfireball.net/projects/markdown/syntax)
-
 # A mixin for aquatic creatures.
+#
+# @see [YARD Documentation](https://yardoc.org/)
+# @see [Markdown Syntax](https://daringfireball.net/projects/markdown/syntax)
+#
 module Aquatic
   # Swim in the water.
   #
@@ -135,11 +131,9 @@ class Salmon < Fish
   end
 end
 
-# @!constant [Integer] DEFAULT_SALMON_SPEED
-#   Default speed for a swimming salmon
+# Default speed for a swimming salmon
 DEFAULT_SALMON_SPEED = 20
 
-# @!constant [Integer] MAX_DEPTH
 #   Maximum depth for salmon habitat
 MAX_DEPTH = 500
 

--- a/example_yard.rb
+++ b/example_yard.rb
@@ -1,8 +1,5 @@
 # A mixin for aquatic creatures.
 #
-# @see [YARD Documentation](https://yardoc.org/)
-# @see [Markdown Syntax](https://daringfireball.net/projects/markdown/syntax)
-#
 module Aquatic
   # Swim in the water.
   #

--- a/templates/default/fulldoc/markdown/setup.rb
+++ b/templates/default/fulldoc/markdown/setup.rb
@@ -143,7 +143,7 @@ def serialize(object)
 <% groups(constant_listing, "Constants") do |list, name| %>
 # <%= name %>
 <% if list.size > 0 %>
-| Name | Value |
+| Name | Default Value |
 | ---  | ---   |
 <% list.each do |cnst| %>
 | [<%= cnst.name %>](#<%=aref(cnst)%>) | <%= cnst.value %> |

--- a/templates/default/fulldoc/markdown/setup.rb
+++ b/templates/default/fulldoc/markdown/setup.rb
@@ -126,9 +126,7 @@ def serialize(object)
 ## <%= item.name(false) %>(<%= item.parameters.map {|p| p.join(" ") }.join(", ") %>) [](#<%=aref(item)%>)
 <%= rdoc_to_md item.docstring %>
 <%= render_tags item %>
-
-<% end %>
-<% end %>
+<% end %><% end %>
 <% if (attrs = attr_listing(object)).size > 0 %>
 # Attributes
 <% attrs.each do |item|%>
@@ -136,9 +134,7 @@ def serialize(object)
 <%= rdoc_to_md item.docstring %>
 
 <%= render_tags item %>
-<% end %>
-<% end %>
-
+<% end %><% end %>
 <% if constant_listing.size > 0 %>
 <% groups(constant_listing, "Constants") do |list, name| %>
 # <%= name %>

--- a/templates/default/fulldoc/markdown/setup.rb
+++ b/templates/default/fulldoc/markdown/setup.rb
@@ -143,10 +143,10 @@ def serialize(object)
 <% groups(constant_listing, "Constants") do |list, name| %>
 # <%= name %>
 <% if list.size > 0 %>
-| Name | Value | Title |
-| ---  | ---   | ---   |
+| Name | Value |
+| ---  | ---   |
 <% list.each do |cnst| %>
-| [<%= cnst.name %>](#<%=aref(cnst)%>) | <%= cnst.value %> |<%= cnst.sep %> |
+| [<%= cnst.name %>](#<%=aref(cnst)%>) | <%= cnst.value %> |
 <% end %><% end %><% end %><% end %>',
       trim_mode: "<>",
     )

--- a/templates/default/fulldoc/markdown/setup.rb
+++ b/templates/default/fulldoc/markdown/setup.rb
@@ -142,13 +142,12 @@ def serialize(object)
 <% if constant_listing.size > 0 %>
 <% groups(constant_listing, "Constants") do |list, name| %>
 # <%= name %>
+<% if list.size > 0 %>
+| Name | Value | Title |
+| ---  | ---   | ---   |
 <% list.each do |cnst| %>
-## <%= cnst.name %> [](#<%=aref(cnst)%>)
-<%= rdoc_to_md cnst.docstring %>
-
-<%= render_tags cnst %>
-
-<% end %><% end %><% end %>',
+| [<%= cnst.name %>](#<%=aref(cnst)%>) | <%= cnst.value %> |<%= cnst.sep %> |
+<% end %><% end %><% end %><% end %>',
       trim_mode: "<>",
     )
 

--- a/yard-markdown.gemspec
+++ b/yard-markdown.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "yard-markdown"
-  spec.version = "0.4"
+  spec.version = "0.4.1"
   spec.authors = ["Stanislav (Stas) Katkov"]
   spec.email = ["yard-markdown@skatkov.com"]
 


### PR DESCRIPTION
Use markdown table to render list of constants (name and default value).

![Screenshot From 2024-12-16 03-59-11](https://github.com/user-attachments/assets/20dccad6-a5fd-4435-bc2b-a7b1709569b9)

I so far, didn't figure out how to add comment for constant (docstring is missing).
