### PR TITLE
Remove defined-in and constants

### DIFF
--- a/templates/default/fulldoc/markdown/setup.rb
+++ b/templates/default/fulldoc/markdown/setup.rb
@@ -104,33 +104,13 @@ def serialize(object)
   <% if (mix = run_verifier(object.mixins(scope))).size > 0 %>
 **<%= name %>:** <%= mix.sort_by {|o| o.path }.join(", ") %>
   <% end %><% end %>
-<% unless object.root? %>
-**Defined in:** <%= object.file ? object.file.sub(Dir.pwd, "") : "(unknown)" %>
-<% end %>
 
 <%= rdoc_to_md object.docstring %>
 
 <%= render_tags object %>
 
-<% if constant_listing.size > 0 %>
-<% groups(constant_listing, "Constants") do |list, name| %>
-<% if list.size > 0 %>
-| <%= name %> | Default Value |
-| ---  | ---   |
-<% list.each do |cnst| %>
-| [<%= cnst.name %>](#<%=aref(cnst)%>) | <%= cnst.value %> |
-<% end %><% end %><% end %><% end %>
-<% if (insmeths = public_instance_methods(object)).size > 0 %>
-# Public Instance Methods
-<% insmeths.each do |item| %>
-## <%= item.name(false) %>(<%= item.parameters.map {|p| p.join("") }.join(", ")%>) [](#<%=aref(item)%>)
-<%= rdoc_to_md item.docstring %>
-
-<%= render_tags item %>
-<% end %><% end %>
-
 <% if (pubmeths = public_class_methods(object)).size > 0 %>
-# Public Class Methods
+# Class Methods
 <% pubmeths.each do |item| %>
 ## <%= item.name(false) %>(<%= item.parameters.map {|p| p.join(" ") }.join(", ") %>) [](#<%=aref(item)%>)
 <%= rdoc_to_md item.docstring %>
@@ -140,6 +120,15 @@ def serialize(object)
 # Attributes
 <% attrs.each do |item|%>
 ## <%= item.name %><%= item.reader? ? "[RW]" : "[R]" %> [](#<%=aref(item)%>)
+<%= rdoc_to_md item.docstring %>
+
+<%= render_tags item %>
+<% end %><% end %>
+
+<% if (insmeths = public_instance_methods(object)).size > 0 %>
+#Instance Methods
+<% insmeths.each do |item| %>
+## <%= item.name(false) %>(<%= item.parameters.map {|p| p.join("") }.join(", ")%>) [](#<%=aref(item)%>)
 <%= rdoc_to_md item.docstring %>
 
 <%= render_tags item %>


### PR DESCRIPTION
I'm still trying to nail down a proper structure for markdown output.

In this release, I'm trying to remove:
- "defined in" section -- there are multiple issues with getting this section right, so let's drop it for now.
- constants section -- table view doesn't work and I generally don't consider those critical enough to take so much space. It would also add, that there are too much constant shown )might be inherited).
- swap place "class methods" section and "instant methods" section