### PR TITLE
Honor YARD visibility flags in markdown output

### DIFF
--- a/templates/default/fulldoc/markdown/setup.rb
+++ b/templates/default/fulldoc/markdown/setup.rb
@@ -53,7 +53,7 @@ def serialize_index(objects)
         end
       end
 
-      if (insmeths = public_instance_methods(object)).size > 0
+      if (insmeths = visible_instance_methods(object)).size > 0
         insmeths.each do |item|
           csv << [
             "#{object.path}.#{item.name(false)}",
@@ -63,7 +63,7 @@ def serialize_index(objects)
         end
       end
 
-      if (pubmeths = public_class_methods(object)).size > 0
+      if (pubmeths = visible_class_methods(object)).size > 0
         pubmeths.each do |item|
           csv << [
             "#{object.path}.#{item.name(false)}",
@@ -110,24 +110,22 @@ def anchor_component(value)
 end
 
 def constant_listing(object)
-  constants = object.constants(included: false, inherited: false)
-  constants + object.cvars
+  constants = object.constants(included: false, inherited: false) + object.cvars
+  run_verifier(constants)
 end
 
-def public_method_list(object)
-  prune_method_listing(
-    object.meths(inherited: false, visibility: [:public]),
-    included: false
-  ).reject { |item| hidden_object?(item) }
+def visible_method_list(object)
+  prune_method_listing(object.meths(inherited: false, included: false))
+    .reject { |item| hidden_object?(item) }
     .sort_by { |m| m.name.to_s }
 end
 
-def public_class_methods(object)
-  public_method_list(object).select { |o| o.scope == :class }
+def visible_class_methods(object)
+  visible_method_list(object).select { |o| o.scope == :class }
 end
 
-def public_instance_methods(object)
-  public_method_list(object).select { |o| o.scope == :instance }
+def visible_instance_methods(object)
+  visible_method_list(object).select { |o| o.scope == :instance }
 end
 
 def attr_listing(object)

--- a/test/example/visibility_example.rb
+++ b/test/example/visibility_example.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class VisibilityExample
+  # Public method.
+  def public_api
+    true
+  end
+
+  protected
+
+  # Protected method.
+  def protected_api
+    true
+  end
+
+  private
+
+  # Private method.
+  def private_api
+    true
+  end
+
+  # @private
+  # Internal private method that should be hidden with --no-private.
+  def private_tagged_api
+    true
+  end
+
+  # @private
+  # Constant hidden by --no-private.
+  INTERNAL_TOKEN = 'secret'
+end

--- a/test/yard/test_template_sections.rb
+++ b/test/yard/test_template_sections.rb
@@ -19,6 +19,10 @@ class YARD::TestTemplateSections < Minitest::Test
         attributes_section
         public_class_methods_section
         public_instance_methods_section
+        protected_class_methods_section
+        protected_instance_methods_section
+        private_class_methods_section
+        private_instance_methods_section
       ],
       template.sections.map(&:name)
     )


### PR DESCRIPTION
## Summary
- Respect YARD verifier visibility filters for markdown method/constant listings so `--protected`, `--private`, and `--no-private` alter output as expected.
- Add protected/private markdown sections in the module template so newly visible methods are rendered under the correct headings.
- Add fixture + regression tests that exercise visibility flags and verify both markdown pages and `index.csv` entries.

## Testing
- bundle exec rake test
- bundle exec rake markdown:validate_real_world

## Notes
- This PR is based on #29 (`issue-5-modular-markdown-template`) and should merge after it.

Closes #9.